### PR TITLE
Adds pre-commit for auto ruff before commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.8.1
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ To integrate this plugin with your NOMAD installation:
 
 2. For more detailed installation instructions, visit our [docs for NOMAD plugins](https://nomad-lab.eu/prod/v1/staging/docs/plugins/plugins.html).
 
+## Developers
+
+It's nice to not miss a ruff fromat before pushing your commits. To set up pre-commit hook:
+```console
+   pip install pre-commit
+   pre-commit install
+```
+
 ### Acknowledgments
 Special thanks to Jinzhao Li and all contributors who have made this project possible.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To integrate this plugin with your NOMAD installation:
 
 ## Developers
 
-It's nice to not miss a ruff fromat before pushing your commits. To set up pre-commit hook:
+It's nice to not miss a ruff format before pushing your commits. To set up pre-commit hook:
 ```console
    pip install pre-commit
    pre-commit install


### PR DESCRIPTION
## Developers

It's nice to not miss a ruff format before pushing your commits. To set up pre-commit hook:
```console
   pip install pre-commit
   pre-commit install
```

## Summary by Sourcery

Introduce a pre-commit hook configuration to automatically run Ruff linter and formatter before commits, and update the README with setup instructions for developers.

Build:
- Add a pre-commit configuration file to automate running Ruff linter and formatter before commits.

Documentation:
- Update README with instructions for setting up pre-commit hooks for Ruff.