### PR TITLE
Fix: Handle mTorr as unit and numeric check for coefficients

### DIFF
--- a/src/perovskite_solar_cell_database/parsers/tandem_parser.py
+++ b/src/perovskite_solar_cell_database/parsers/tandem_parser.py
@@ -79,6 +79,8 @@ ureg = UnitRegistry()
 ureg.define('% = 0.01 * [] = percent')
 ureg.define('wt% = 0.01 * gram/gram = weight_percent')
 ureg.define('vol% = 0.01* liter/liter = volume_percent')
+ureg.define('mTorr = millitorr')
+ureg.define('Torr = torr')
 
 unit_pattern = re.compile(
     r'^(\d+(\.\d+)?|\.\d+)([eE][-+]?\d+)?\s*\w+([*/^]\w+)*(\s*[/()]\s*\w+)*$'
@@ -671,10 +673,18 @@ def extract_chalcopyrite_additives(data_frame):
     return additives if additives else None
 
 
-def extract_chalcopyrite_composition(data_frame):
+ef extract_chalcopyrite_composition(data_frame):
     """
     Extracts the composition from the data subframe and returns a list of Ion objects.
     """
+
+    def get_coefficient(component_data):
+        coefficient = partial_get(
+            component_data,
+            'Chalcopyrite. Composition. Ions. Coefficients',
+            convert=True,
+        )
+        return coefficient if isinstance(coefficient, (float, int)) else None
 
     df_temp = data_frame[data_frame.index.str.contains('Chalcopyrite. Composition')]
     if df_temp.empty:
@@ -686,11 +696,7 @@ def extract_chalcopyrite_composition(data_frame):
             name=partial_get(
                 df_components[component], 'Chalcopyrite. Composition. Ions '
             ),
-            coefficient=partial_get(
-                df_components[component],
-                'Chalcopyrite. Composition. Ions. Coefficients',
-                convert=True,
-            ),
+            coefficient=get_coefficient(df_components[component]),
         )
         for component in df_components.columns
     ]

--- a/src/perovskite_solar_cell_database/parsers/tandem_parser.py
+++ b/src/perovskite_solar_cell_database/parsers/tandem_parser.py
@@ -673,7 +673,7 @@ def extract_chalcopyrite_additives(data_frame):
     return additives if additives else None
 
 
-ef extract_chalcopyrite_composition(data_frame):
+def extract_chalcopyrite_composition(data_frame):
     """
     Extracts the composition from the data subframe and returns a list of Ion objects.
     """


### PR DESCRIPTION
## Summary by Sourcery

Fixes a bug where mTorr was not recognized as a unit. Also fixes a bug where the coefficient of an ion in the chalcopyrite composition was not correctly extracted if it was not a number.

Bug Fixes:
- Fixes a bug where mTorr was not recognized as a unit.
- Fixes a bug where the coefficient of an ion in the chalcopyrite composition was not correctly extracted if it was not a number.