### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -29,7 +28,7 @@ maintainers = [
     {name = "Jose Marquez", email = "jose.marquez@physik.hu-berlin.de"},
     {name = "Hampus Näsström", email = "hampus.naesstroem@physik.hu-berlin.de"},
     ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "nomad-lab>=1.3.11.dev29",
     "nomad-schema-plugin-run>=1.0.1",


### PR DESCRIPTION
## Summary by Sourcery

Drop support for Python 3.9 and update project configuration

Build:
- Update minimum Python version requirement from 3.9 to 3.10 in pyproject.toml

Chores:
- Remove Python 3.9 from supported Python versions in project configuration