### PR TITLE
Add mkdocs-glightbox to development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pymdown-extensions",
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
+    "mkdocs-glightbox",
     "pydantic>=2.0,<2.11"
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add mkdocs-glightbox plugin to improve documentation image viewing capabilities