### PR TITLE
Import from nomad-docs

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -1,1 +1,1 @@
-from nomad.mkdocs import define_env
+from nomad_docs import define_env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ dev = [
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
     "mkdocs-glightbox",
-    "pydantic>=2.0,<2.11"
+    "pydantic>=2.0,<2.11",
+    "nomad-docs>=0.1.3"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
change import from nomad.mkdocs to import from nomad-docs; update requirements

## Summary by Sourcery

Update documentation tooling to import the Nomad mkdocs plugin from the new nomad-docs package and add it as a dependency

Enhancements:
- Replace import statements in docs/main.py to use nomad-docs instead of nomad.mkdocs

Build:
- Add nomad-docs>=0.1.3 to project dependencies in pyproject.toml