### PR TITLE
Bugfix for measurements with missing results subsection in tandem json files

### DIFF
--- a/src/perovskite_solar_cell_database/schema_packages/tandem/schema.py
+++ b/src/perovskite_solar_cell_database/schema_packages/tandem/schema.py
@@ -128,11 +128,11 @@ class PerovskiteTandemSolarCell(Schema, PlotSection):
                     and measurement.light_regime == 'standard_light'
                 ):
                     # Extract the PCE if it excist
-                    results = measurement.results
-                    pce_value = results.power_conversion_efficiency
-                    if pce_value is not None:
-                        pce.append(pce_value)
-                        pce_index.append(i)
+                    if measurement.results is not None:
+                        pce_value = measurement.results.power_conversion_efficiency
+                        if pce_value is not None:
+                            pce.append(pce_value)
+                            pce_index.append(i)
 
         # Identify the JV measurement with the highest PCE
         if pce:
@@ -192,10 +192,11 @@ class PerovskiteTandemSolarCell(Schema, PlotSection):
                     and measurement.light_regime == 'standard_light'
                 ):
                     # Extract the PCE if it excist
-                    pce_value = measurement.results.power_conversion_efficiency
-                    if pce_value is not None:
-                        pce.append(pce_value)
-                        pce_index.append(i)
+                    if measurement.results is not None:
+                        pce_value = measurement.results.power_conversion_efficiency
+                        if pce_value is not None:
+                            pce.append(pce_value)
+                            pce_index.append(i)
 
         if pce:
             i_best_pce = pce_index[pce.index(max(pce))]

--- a/src/perovskite_solar_cell_database/schema_packages/tandem/schema.py
+++ b/src/perovskite_solar_cell_database/schema_packages/tandem/schema.py
@@ -127,7 +127,7 @@ class PerovskiteTandemSolarCell(Schema, PlotSection):
                     measurement.device_subset == 0
                     and measurement.light_regime == 'standard_light'
                 ):
-                    # Extract the PCE if it excist
+                    # Extract the PCE if it exists
                     if measurement.results is not None:
                         pce_value = measurement.results.power_conversion_efficiency
                         if pce_value is not None:


### PR DESCRIPTION
should have been a part of this PR: https://github.com/FAIRmat-NFDI/nomad-perovskite-solar-cells-database/pull/72

## Summary by Sourcery

Bug Fixes:
- Add checks for None measurement.results before accessing power_conversion_efficiency in the normalization pipeline.