### PR TITLE
Add LLM perovskite paper extractor schema

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,8 @@ jobs:
     - name: Install uv and set the python version
       uses: astral-sh/setup-uv@v5
       with:
-          python-version: 3.12
+        version: 0.7.x
+        python-version: 3.12
     - name: Install dependencies
       run: |
         uv sync --all-extras

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv run pip install .[dev]
+        uv sync --all-extras
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --all-extras --no-extra extraction
+        uv sync --all-groups --no-group extraction
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --extras dev
+        uv sync --extra dev
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --all-extras
+        uv sync --all-extras --no-extra extraction
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --all-extras --no-extra extraction
+        uv pip install .[dev]
     - name: Test with pytest
       run: |
-        uv run --with coverage coverage run -m pytest -sv
+        uv run --no-sync --with coverage coverage run -m pytest -sv
     - name: Submit to coveralls
       continue-on-error: true
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        uv run --with coveralls coveralls --service=github
+        uv run --no-sync --with coveralls coveralls --service=github
 
   ruff-linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --no-install-package perovscribe --all-extras
+        uv pip install .[dev]
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --extra dev
+        uv sync --all-extras --no-extra extraction
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --all-groups --no-group extraction
+        uv sync --frozen --extra dev
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv pip install .[dev]
+        uv run pip install .[dev]
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --all-extras
+        uv sync --extras dev
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        uv sync --frozen --extra dev
+        uv sync --no-install-package perovscribe --all-extras
     - name: Test with pytest
       run: |
         uv run --with coverage coverage run -m pytest -sv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ dev = [
     "pydantic>=2.0,<2.11",
     "nomad-docs>=0.1.3"
 ]
-# extraction = [
-#     "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git@cacedb25c66a075f4af02c6b481dacaabbbda4fb",
-# ]
+extraction = [
+    "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git@cacedb25c66a075f4af02c6b481dacaabbbda4fb",
+]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "nomad-schema-plugin-simulation-workflow>=1.0.1",
     "rdkit",
     "openpyxl",
-    "lxml_html_clean"
+    "lxml_html_clean",
+    "perovscribe@git+ssh://git@github.com/lamalab-org/perovskite-extraction.git#egg=fixes"
 ]
 license = { file = "LICENSE" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ dev = [
     "pydantic>=2.0,<2.11",
     "nomad-docs>=0.1.3"
 ]
-extraction = [
-    "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git@cacedb25c66a075f4af02c6b481dacaabbbda4fb",
-]
+# extraction = [
+#     "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git@cacedb25c66a075f4af02c6b481dacaabbbda4fb",
+# ]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     "nomad-docs>=0.1.3"
 ]
 extraction = [
-    "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git#egg=fixes",
+    "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git@cacedb25c66a075f4af02c6b481dacaabbbda4fb",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "rdkit",
     "openpyxl",
     "lxml_html_clean",
-    "perovscribe@git+ssh://git@github.com/lamalab-org/perovskite-extraction.git#egg=fixes"
 ]
 license = { file = "LICENSE" }
 
@@ -61,6 +60,9 @@ dev = [
     "mkdocs-glightbox",
     "pydantic>=2.0,<2.11",
     "nomad-docs>=0.1.3"
+]
+extraction = [
+    "perovscribe @ git+ssh://git@github.com/lamalab-org/perovskite-extraction.git#egg=fixes",
 ]
 
 [tool.ruff]

--- a/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_app.py
+++ b/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_app.py
@@ -87,6 +87,7 @@ perovskite_database_app = App(
         Column(quantity='comment'),
         Column(quantity='datasets'),
         Column(quantity='published', label='Access'),
+        Column(quantity=f'data.ref.extraction_method#{schema}', label='Extraction method'),
     ],
     menu=Menu(
         items=[
@@ -113,6 +114,10 @@ perovskite_database_app = App(
                             search_quantity=f'data.ref.publication_date#{schema}',
                             title='Publication Date',
                         )
+                    ),
+                    MenuItemTerms(
+                        search_quantity=f'data.ref.extraction_method#{schema}',
+                        title='Solar Cell Data Extraction Method',
                     ),
                 ],
             ),

--- a/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_app.py
+++ b/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_app.py
@@ -96,18 +96,18 @@ perovskite_database_app = App(
                 size=MenuSizeEnum.XXL,
                 items=[
                     MenuItemTerms(
+                        search_quantity=f'data.ref.authors.name#{schema}',
+                        show_input=True,
+                        width=6,
+                        options=10,
+                        title='Publication Authors',
+                    ),
+                    MenuItemTerms(
                         search_quantity=f'data.ref.journal#{schema}',
                         show_input=True,
                         width=6,
                         options=10,
                         title='Journal',
-                    ),
-                    MenuItemTerms(
-                        search_quantity=f'data.ref.DOI_number#{schema}',
-                        show_input=True,
-                        width=6,
-                        options=10,
-                        title='DOI',
                     ),
                     MenuItemHistogram(
                         x=Axis(
@@ -118,6 +118,15 @@ perovskite_database_app = App(
                     MenuItemTerms(
                         search_quantity=f'data.ref.extraction_method#{schema}',
                         title='Solar Cell Data Extraction Method',
+                        show_input=False,
+                        width=6,
+                    ),
+                    MenuItemTerms(
+                        search_quantity=f'data.ref.DOI_number#{schema}',
+                        show_input=True,
+                        width=6,
+                        options=5,
+                        title='DOI',
                     ),
                 ],
             ),

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -622,7 +622,7 @@ class LlmPerovskitePaperExtractor(Schema):
             if not self.doi:
                 logger.warn('DOI is required for LLM extraction')
                 return
-            if not self.pdf:
+            if not isinstance(self.pdf, str) or not self.pdf.endswith('.pdf'):
                 logger.warn('PDF file is required for LLM extraction')
                 return
             extracted_cells = pdf_to_solar_cells(

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -600,8 +600,10 @@ class LlmPerovskitePaperExtractor(Schema):
         Deletes the PDF file from the upload.
         """
         if self.pdf:
-            os.remove(self.m_context.raw_path(self.pdf))
-
+            try:
+                os.remove(self.m_context.raw_path(self.pdf))
+            except FileNotFoundError:
+                pass  # File already deleted or does not exist
     def doi_to_name(self) -> str:
         """
         Converts the DOI to a name suitable for the entry.
@@ -654,7 +656,7 @@ def extract_doi(doi: str) -> str:
     and replaces the forward slash ("/") between the prefix and suffix with a double hyphen ("--").
     Returns None if no valid DOI is found.
     """
-    match = re.search(r'10\.\d{4,9}/\S+', doi, re.IGNORECASE)
+    match = re.search(r'10\.\d{4,9}/[-._;()/:\w\[\]]+', doi, re.IGNORECASE)
     if match:
         return match.group(0).replace('/', '--', 1)
     return None

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -615,6 +615,7 @@ class LlmPerovskitePaperExtractor(Schema):
 
     def normalize(self, archive: 'EntryArchive', logger):
         super().normalize(archive, logger)
+        extracted_cells = []
         try:
             if not self.open_ai_token:
                 logger.warn('OpenAI token is required for LLM extraction')
@@ -634,10 +635,15 @@ class LlmPerovskitePaperExtractor(Schema):
             )
         finally:
             self.delete_pdf()  # Delete the PDF after extraction for copyright reasons
+        cell_references = []
         for idx, cell in enumerate(extracted_cells):
             name = f'{self.doi_to_name()}-cell-{idx + 1}'
             with archive.m_context.update_entry(name, write=True, process=True) as entry:
-                entry['data'] = cell
+                entry['data'] = cell 
+            cell_references.append(get_reference(
+                upload_id=archive.metadata.upload_id, mainfile=name
+            ))
+        self.extracted_solar_cells = cell_references
 
 
 def pdf_to_solar_cells(pdf: str, doi: str, open_ai_token: str) -> list[dict]:

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -669,6 +669,7 @@ class LlmPerovskitePaperExtractor(Schema):
                 pdf=os.path.join(archive.m_context.raw_path(), self.pdf),
                 doi=self.doi,
                 open_ai_token=_open_ai_token,
+                logger=logger,
             )
         finally:
             self.delete_pdf()  # Delete the PDF after extraction for copyright reasons

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -601,9 +601,11 @@ class LlmPerovskitePaperExtractor(Schema):
         """
         if self.pdf:
             try:
-                os.remove(self.m_context.raw_path() + self.pdf)
+                os.remove(os.path.join(self.m_context.raw_path(), self.pdf))
+                self.pdf = None  # Clear the reference to the deleted file
             except FileNotFoundError:
                 pass  # File already deleted or does not exist
+    
     def doi_to_name(self) -> str:
         """
         Converts the DOI to a name suitable for the entry.
@@ -611,7 +613,6 @@ class LlmPerovskitePaperExtractor(Schema):
         if not self.doi:
             return 'unnamed'
         return extract_doi(self.doi) or 'unnamed'
-        
 
     def normalize(self, archive: 'EntryArchive', logger):
         super().normalize(archive, logger)
@@ -629,7 +630,7 @@ class LlmPerovskitePaperExtractor(Schema):
                 logger.warn('PDF file is required for LLM extraction')
                 return
             extracted_cells = pdf_to_solar_cells(
-                pdf=archive.m_context.raw_path() + self.pdf,
+                pdf=os.path.join(archive.m_context.raw_path(), self.pdf),
                 doi=self.doi,
                 open_ai_token=_open_ai_token,
             )

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -4,7 +4,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from nomad.datamodel.data import ArchiveSection
+from nomad.datamodel.data import ArchiveSection, UseCaseElnCategory
 from nomad.datamodel.metainfo.annotations import ELNComponentEnum
 from nomad.datamodel.metainfo.basesections import PublicationReference
 from nomad.datamodel.metainfo.eln import ELNAnnotation
@@ -572,6 +572,10 @@ Sometimes several different PCE values are presented for the same device. It cou
 
 
 class LlmPerovskitePaperExtractor(Schema):
+    m_def = Section(
+        label='LLM Perovskite Paper Extractor',
+        categories=[UseCaseElnCategory],
+    )
     pdf = Quantity(
         type=str,
         a_eln=ELNAnnotation(component=ELNComponentEnum.FileEditQuantity),
@@ -781,15 +785,18 @@ def llm_to_classic_schema(
     perovskite.composition_a_ions = '; '.join(ion.abbreviation for ion in a_ions)
     perovskite.composition_b_ions = '; '.join(ion.abbreviation for ion in b_ions)
     perovskite.composition_c_ions = '; '.join(ion.abbreviation for ion in x_ions)
-    perovskite.composition_a_ions_coefficients = '; '.join(
-        ion.coefficient for ion in a_ions
-    )
-    perovskite.composition_b_ions_coefficients = '; '.join(
-        ion.coefficient for ion in b_ions
-    )
-    perovskite.composition_c_ions_coefficients = '; '.join(
-        ion.coefficient for ion in x_ions
-    )
+    if a_ions:
+        perovskite.composition_a_ions_coefficients = '; '.join(
+            ion.coefficient for ion in a_ions
+        )
+    if b_ions:
+        perovskite.composition_b_ions_coefficients = '; '.join(
+            ion.coefficient for ion in b_ions
+        )
+    if x_ions:
+        perovskite.composition_c_ions_coefficients = '; '.join(
+            ion.coefficient for ion in x_ions
+        )
     perovskite.band_gap = llm_composition.band_gap
     # Still needs to be read:
     # llm_composition.impurities

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -601,7 +601,7 @@ class LlmPerovskitePaperExtractor(Schema):
         """
         if self.pdf:
             try:
-                os.remove(self.m_context.raw_path(self.pdf))
+                os.remove(self.m_context.raw_path() + self.pdf)
             except FileNotFoundError:
                 pass  # File already deleted or does not exist
     def doi_to_name(self) -> str:
@@ -629,7 +629,7 @@ class LlmPerovskitePaperExtractor(Schema):
                 logger.warn('PDF file is required for LLM extraction')
                 return
             extracted_cells = pdf_to_solar_cells(
-                pdf=archive.m_context.raw_path(self.pdf),
+                pdf=archive.m_context.raw_path() + self.pdf,
                 doi=self.doi,
                 open_ai_token=_open_ai_token,
             )

--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -638,13 +638,14 @@ class LlmPerovskitePaperExtractor(Schema):
             self.delete_pdf()  # Delete the PDF after extraction for copyright reasons
         cell_references = []
         for idx, cell in enumerate(extracted_cells):
-            name = f'{self.doi_to_name()}-cell-{idx + 1}'
+            name = f'{self.doi_to_name()}-cell-{idx + 1}.archive.json'
             with archive.m_context.update_entry(name, write=True, process=True) as entry:
                 entry['data'] = cell 
             cell_references.append(get_reference(
                 upload_id=archive.metadata.upload_id, mainfile=name
             ))
-        self.extracted_solar_cells = cell_references
+        if cell_references:
+            self.extracted_solar_cells = cell_references
 
 
 def pdf_to_solar_cells(pdf: str, doi: str, open_ai_token: str) -> list[dict]:
@@ -654,7 +655,10 @@ def pdf_to_solar_cells(pdf: str, doi: str, open_ai_token: str) -> list[dict]:
     """
     # Placeholder for actual extraction logic
     # This should return a list of LLMExtractedPerovskiteSolarCell instances as dicts
-    return []  # Replace with actual extraction logic (e.g., using OpenAI API)
+    return [{
+        "m_def": "perovskite_solar_cell_database.llm_extraction_schema.LLMExtractedPerovskiteSolarCell",
+        "DOI_number": doi,
+    }]  # Replace with actual extraction logic (e.g., using OpenAI API)
 
 
 def extract_doi(doi: str) -> str:

--- a/src/perovskite_solar_cell_database/schema_sections/ref.py
+++ b/src/perovskite_solar_cell_database/schema_sections/ref.py
@@ -1,6 +1,9 @@
 import numpy as np
 from nomad.datamodel.data import ArchiveSection
 from nomad.metainfo import Datetime, Quantity, Section
+from nomad.metainfo.metainfo import MEnum, SchemaPackage
+
+m_package = SchemaPackage()
 
 
 class Ref(ArchiveSection):
@@ -114,6 +117,11 @@ Unpublished
                     """,
     )
 
+    extraction_method = Quantity(
+        type=MEnum('Author', 'Perovskite Database Project', 'LLM', 'LLM Reviewed by Human'),
+        description='How the solar cell data was extracted from the publication.',
+    )
+
     def normalize(self, archive, logger):
         import dateutil.parser
         import requests
@@ -150,3 +158,6 @@ Unpublished
             for i, ref in enumerate(archive.metadata.references):
                 if ref.startswith('10.'):
                     archive.metadata.references[i] = 'https://doi.org/' + ref
+
+
+m_package.__init_metainfo__()

--- a/tests/data/10.1002--adfm.201904856-cell-1.archive.json
+++ b/tests/data/10.1002--adfm.201904856-cell-1.archive.json
@@ -309,6 +309,9 @@
             }
         ],
         "DOI_number": "https://www.doi.org/10.1002/adfm.201904856",
-        "m_def": "perovskite_solar_cell_database.llm_extraction_schema.LLMExtractedPerovskiteSolarCell"
+        "m_def": "perovskite_solar_cell_database.llm_extraction_schema.LLMExtractedPerovskiteSolarCell",
+        "extraction_metadata": {
+            "model": "GPT-4.1"
+        }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement a new schema to automate extraction of perovskite solar cell information from PDF papers using an LLM, including input handling, DOI normalization, and per-cell entry creation

New Features:
- Introduce LlmPerovskitePaperExtractor schema for extracting perovskite solar cell data from research papers using an LLM
- Add PDF, DOI, OpenAI token, and extracted solar cell list quantities to the schema
- Implement normalization logic to validate inputs, invoke LLM extraction, delete the PDF, and create entries for each extracted cell

Enhancements:
- Add pdf_to_solar_cells placeholder function for future LLM extraction logic
- Add extract_doi helper to normalize DOI strings into entry-safe names