### PR TITLE
Disallow pre-release in mkdocs-deploy.yml

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Build and Deploy
         run: |
-          uv run --extra dev --prerelease=allow mkdocs gh-deploy --force --remote-branch gh-pages
+          uv run --extra dev mkdocs gh-deploy --force --remote-branch gh-pages


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the `--prerelease=allow` option from the mkdocs gh-deploy command in mkdocs-deploy.yml