### PR TITLE
Add sorting of ions in composition and test

### DIFF
--- a/src/perovskite_solar_cell_database/composition.py
+++ b/src/perovskite_solar_cell_database/composition.py
@@ -844,8 +844,17 @@ class PerovskiteCompositionSection(ArchiveSection):
         Returns:
             str: The formula string.
         """
+        a_ions_sorted = sorted(
+            self.ions_a_site, key=lambda ion: ion.abbreviation or ''
+        )
+        b_ions_sorted = sorted(
+            self.ions_b_site, key=lambda ion: ion.abbreviation or ''
+        )
+        x_ions_sorted = sorted(
+            self.ions_x_site, key=lambda ion: ion.abbreviation or ''
+        )
         ions: list[PerovskiteIonComponent] = (
-            self.ions_a_site + self.ions_b_site + self.ions_x_site
+            a_ions_sorted + b_ions_sorted + x_ions_sorted
         )
         self.short_form = ''
         self.long_form = ''
@@ -976,7 +985,7 @@ class PerovskiteComposition(PerovskiteCompositionSection, CompositeSystem, Entry
         add_system_info(parent_system, topology)
 
         for ion in self.components:
-            child_system = ion.to_topology_system(logger=logger)
+            child_system = ion.to_topology_system()
             add_system(child_system, topology, parent_system)
             add_system_info(child_system, topology)
 

--- a/tests/data/Br_perovskite_ion.archive.json
+++ b/tests/data/Br_perovskite_ion.archive.json
@@ -1,0 +1,1 @@
+{"data": {"m_def": "perovskite_solar_cell_database.composition.PerovskiteXIon", "common_name": "Bromide", "molecular_formula": "Br-", "smiles": "[Br-]", "iupac_name": "Bromide", "cas_number": "24959-67-9", "abbreviation": "Br", "source_compound_smiles": "BrBr", "source_compound_iupac_name": "molecular bromine", "source_compound_cas_number": "7726-95-6"}}

--- a/tests/data/I_perovskite_ion.archive.json
+++ b/tests/data/I_perovskite_ion.archive.json
@@ -1,0 +1,1 @@
+{"data": {"m_def": "perovskite_solar_cell_database.composition.PerovskiteXIon", "common_name": "Iodide", "molecular_formula": "I-", "smiles": "[I-]", "iupac_name": "Iodide", "cas_number": "20461-54-5", "abbreviation": "I", "source_compound_smiles": "II", "source_compound_iupac_name": "molecular iodine", "source_compound_cas_number": "7553-56-2"}}

--- a/tests/data/MA_perovskite_ion.archive.json
+++ b/tests/data/MA_perovskite_ion.archive.json
@@ -1,0 +1,1 @@
+{"data": {"m_def": "perovskite_solar_cell_database.composition.PerovskiteAIon", "common_name": "Methylammonium", "molecular_formula": "CH6N+", "smiles": "C[NH3+]", "iupac_name": "methylazanium", "cas_number": "17000-00-9", "abbreviation": "MA", "source_compound_smiles": "CN", "source_compound_iupac_name": "methanamine", "source_compound_cas_number": "74-89-5"}}

--- a/tests/data/Pb_perovskite_ion.archive.json
+++ b/tests/data/Pb_perovskite_ion.archive.json
@@ -1,0 +1,1 @@
+{"data": {"m_def": "perovskite_solar_cell_database.composition.PerovskiteBIon", "common_name": "Lead", "molecular_formula": "Pb2+", "smiles": "[Pb+2]", "iupac_name": "lead(2+)", "cas_number": "14280-50-3", "abbreviation": "Pb", "source_compound_smiles": "[Pb]", "source_compound_iupac_name": "Lead", "source_compound_cas_number": "7439-92-1"}}

--- a/tests/data/composition.archive.yaml
+++ b/tests/data/composition.archive.yaml
@@ -1,0 +1,17 @@
+data:
+  m_def: perovskite_solar_cell_database.composition.PerovskiteComposition
+  composition_estimate: Estimated from precursor solutions
+  sample_type: Polycrystalline film
+  dimensionality: 3D
+  band_gap: 1.9
+  ions_a_site:
+  - abbreviation: MA
+    coefficient: 1
+  ions_b_site:
+  - abbreviation: Pb
+    coefficient: 1
+  ions_x_site:
+  - abbreviation: I
+    coefficient: 1.5
+  - abbreviation: Br
+    coefficient: 1.5

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,63 @@
+import os.path
+import shutil
+
+import pytest
+from nomad.client import normalize_all, parse
+
+from perovskite_solar_cell_database.composition import (
+    PerovskiteAIon,
+    PerovskiteBIon,
+    PerovskiteComposition,
+    PerovskiteXIon,
+)
+
+
+@pytest.mark.usefixtures('tmp_path')
+def test_composition(tmp_path):
+    a_ion_file = os.path.join(os.path.dirname(__file__), 'data', 'MA_perovskite_ion.archive.json')
+    tmp_file = tmp_path / 'a_ion.archive.json'
+    shutil.copy(a_ion_file, tmp_file)
+    a_ion_archive = parse(tmp_file)[0]
+    normalize_all(a_ion_archive)
+
+    b_ion_file = os.path.join(os.path.dirname(__file__), 'data', 'Pb_perovskite_ion.archive.json')
+    tmp_file = tmp_path / 'b_ion.archive.json'
+    shutil.copy(b_ion_file, tmp_file)
+    b_ion_archive = parse(tmp_file)[0]
+    normalize_all(b_ion_archive)
+
+    x_ion_file_1 = os.path.join(os.path.dirname(__file__), 'data', 'I_perovskite_ion.archive.json')
+    tmp_file = tmp_path / 'x_ion.archive.json'
+    shutil.copy(x_ion_file_1, tmp_file)
+    x_ion_1_archive = parse(tmp_file)[0]
+    normalize_all(x_ion_1_archive)
+
+    x_ion_file_2 = os.path.join(os.path.dirname(__file__), 'data', 'Br_perovskite_ion.archive.json')
+    tmp_file = tmp_path / 'x_ion_2.archive.json'
+    shutil.copy(x_ion_file_2, tmp_file)
+    x_ion_2_archive = parse(tmp_file)[0]
+    normalize_all(x_ion_2_archive)
+
+    a_ion = a_ion_archive.data
+    assert isinstance(a_ion, PerovskiteAIon)
+    b_ion = b_ion_archive.data
+    assert isinstance(b_ion, PerovskiteBIon)
+    x_ion_1 = x_ion_1_archive.data
+    assert isinstance(x_ion_1, PerovskiteXIon)
+    x_ion_2 = x_ion_2_archive.data
+    assert isinstance(x_ion_2, PerovskiteXIon)
+    
+    composition_file = os.path.join(os.path.dirname(__file__), 'data', 'composition.archive.yaml')
+    tmp_file = tmp_path / 'composition.archive.yaml'
+    shutil.copy(composition_file, tmp_file)
+    composition_archive = parse(tmp_file)[0]
+    assert isinstance(composition_archive.data, PerovskiteComposition)
+    composition_archive.data.ions_a_site[0].system = a_ion
+    composition_archive.data.ions_b_site[0].system = b_ion
+    composition_archive.data.ions_x_site[0].system = x_ion_1
+    composition_archive.data.ions_x_site[1].system = x_ion_2
+    normalize_all(composition_archive)
+
+    # Check that short and long form are sorted correctly
+    assert composition_archive.data.short_form == 'MAPbBrI'
+    assert composition_archive.data.long_form == 'MAPbBr1.5I1.5'


### PR DESCRIPTION
## Summary by Sourcery

Implement deterministic sorting of perovskite composition ions by abbreviation for formula generation, streamline normalization by removing logger argument, and add tests with sample data to validate the updated behavior

New Features:
- Sort A, B, and X site ions by abbreviation when constructing formula strings in compositions

Enhancements:
- Remove unnecessary logger parameter when converting ions to topology systems during normalization

Tests:
- Add tests and sample archive data to verify deterministic sorting and correct short/long formula output