### PR TITLE
Add correct spacing for string separators in LLM generated classic cells

### DIFF
--- a/src/perovskite_solar_cell_database/llm_extraction_schema.py
+++ b/src/perovskite_solar_cell_database/llm_extraction_schema.py
@@ -649,7 +649,7 @@ def add_to_pipe_separated_list(existing: str | None, addition: str | None) -> st
     if not addition:
         return existing or 'Unknown'
     if existing:
-        return existing + '|' + addition
+        return existing + ' | ' + addition
     else:
         return addition or 'Unknown'
 
@@ -667,7 +667,7 @@ def set_layer_properties(
     ]
     depositions = [step for step in depositions if step.method != 'Thermal-annealing']
     if isinstance(layer, PerovskiteDeposition):
-        layer.procedure = '>>'.join(deposition.method for deposition in depositions)
+        layer.procedure = ' >> '.join(deposition.method for deposition in depositions)
         layer.number_of_deposition_steps = len(depositions)
     elif not isinstance(layer, Perovskite):
         layer.stack_sequence = add_to_pipe_separated_list(
@@ -675,7 +675,7 @@ def set_layer_properties(
         )
         layer.deposition_procedure = add_to_pipe_separated_list(
             layer.deposition_procedure,
-            '>>'.join(deposition.method for deposition in depositions),
+            ' >> '.join(deposition.method for deposition in depositions),
         )
     if isinstance(layer, HTL | Backcontact):
         layer.thickness_list = add_to_pipe_separated_list(
@@ -743,8 +743,8 @@ def set_layer_properties(
                         if solvent.volume_fraction is not None
                         else 'nan'
                     )
-                solvents.append(';'.join(step_solvents))
-                solvent_fractions.append(';'.join(step_solvent_fractions))
+                solvents.append('; '.join(step_solvents))
+                solvent_fractions.append('; '.join(step_solvent_fractions))
             else:
                 solvents.append('Unknown')
                 solvent_fractions.append('nan')
@@ -757,8 +757,8 @@ def set_layer_properties(
                     step_solute_concentrations.append(
                         f'{quantity_to_str(solute.concentration)} {solute.concentration_unit}'
                     )
-                solutes.append(';'.join(step_solutes))
-                solute_concentrations.append(';'.join(step_solute_concentrations))
+                solutes.append('; '.join(step_solutes))
+                solute_concentrations.append('; '.join(step_solute_concentrations))
             else:
                 solutes.append('Unknown')
                 solute_concentrations.append('nan')
@@ -777,54 +777,54 @@ def set_layer_properties(
             )
     if isinstance(layer, ETL | HTL | Backcontact):
         layer.deposition_synthesis_atmosphere = add_to_pipe_separated_list(
-            layer.deposition_synthesis_atmosphere, '>>'.join(atmospheres)
+            layer.deposition_synthesis_atmosphere, ' >> '.join(atmospheres)
         )
         layer.deposition_substrate_temperature = add_to_pipe_separated_list(
-            layer.deposition_substrate_temperature, '>>'.join(temperatures)
+            layer.deposition_substrate_temperature, ' >> '.join(temperatures)
         )
         layer.deposition_solvents = add_to_pipe_separated_list(
-            layer.deposition_solvents, '>>'.join(solvents)
+            layer.deposition_solvents, ' >> '.join(solvents)
         )
         layer.deposition_reaction_solutions_compounds = add_to_pipe_separated_list(
-            layer.deposition_reaction_solutions_compounds, '>>'.join(solutes)
+            layer.deposition_reaction_solutions_compounds, ' >> '.join(solutes)
         )
         layer.deposition_reaction_solutions_concentrations = add_to_pipe_separated_list(
             layer.deposition_reaction_solutions_concentrations,
-            '>>'.join(solute_concentrations),
+            ' >> '.join(solute_concentrations),
         )
         layer.deposition_reaction_solutions_temperature = add_to_pipe_separated_list(
             layer.deposition_reaction_solutions_temperature,
-            '>>'.join(solution_temperatures),
+            ' >> '.join(solution_temperatures),
         )
         layer.deposition_thermal_annealing_temperature = add_to_pipe_separated_list(
             layer.deposition_thermal_annealing_temperature,
-            '>>'.join(annealing_temperatures),
+            ' >> '.join(annealing_temperatures),
         )
         layer.deposition_thermal_annealing_time = add_to_pipe_separated_list(
-            layer.deposition_thermal_annealing_time, '>>'.join(annealing_durations)
+            layer.deposition_thermal_annealing_time, ' >> '.join(annealing_durations)
         )
         layer.deposition_thermal_annealing_atmosphere = add_to_pipe_separated_list(
             layer.deposition_thermal_annealing_atmosphere,
-            '>>'.join(annealing_atmospheres),
+            ' >> '.join(annealing_atmospheres),
         )
         layer.deposition_reaction_solutions_volumes = add_to_pipe_separated_list(
-            layer.deposition_reaction_solutions_volumes, '>>'.join(volumes)
+            layer.deposition_reaction_solutions_volumes, ' >> '.join(volumes)
         )
     elif isinstance(layer, PerovskiteDeposition):
-        layer.synthesis_atmosphere = '>>'.join(atmospheres)
-        layer.substrate_temperature = '>>'.join(temperatures)
-        layer.reaction_solutions_compounds = '>>'.join(solutes)
-        layer.reaction_solutions_concentrations = '>>'.join(solute_concentrations)
-        layer.reaction_solutions_temperature = '>>'.join(solution_temperatures)
-        layer.solvents = '>>'.join(solvents)
-        layer.solvents_mixing_ratios = '>>'.join(solvent_fractions)
+        layer.synthesis_atmosphere = ' >> '.join(atmospheres)
+        layer.substrate_temperature = ' >> '.join(temperatures)
+        layer.reaction_solutions_compounds = ' >> '.join(solutes)
+        layer.reaction_solutions_concentrations = ' >> '.join(solute_concentrations)
+        layer.reaction_solutions_temperature = ' >> '.join(solution_temperatures)
+        layer.solvents = ' >> '.join(solvents)
+        layer.solvents_mixing_ratios = ' >> '.join(solvent_fractions)
         layer.quenching_induced_crystallisation = quenched
-        layer.quenching_media = '>>'.join(antisolvents)
-        layer.reaction_solutions_volumes = '>>'.join(volumes)
+        layer.quenching_media = ' >> '.join(antisolvents)
+        layer.reaction_solutions_volumes = ' >> '.join(volumes)
         if thermal_annealing_steps:
-            layer.thermal_annealing_temperature = '>>'.join(annealing_temperatures)
-            layer.thermal_annealing_time = '>>'.join(annealing_durations)
-            layer.thermal_annealing_atmosphere = '>>'.join(annealing_atmospheres)
+            layer.thermal_annealing_temperature = ' >> '.join(annealing_temperatures)
+            layer.thermal_annealing_time = ' >> '.join(annealing_durations)
+            layer.thermal_annealing_atmosphere = ' >> '.join(annealing_atmospheres)
 
 
 def llm_to_classic_schema(
@@ -855,7 +855,7 @@ def llm_to_classic_schema(
     cell.architecture = llm_cell.device_architecture
     cell.area_total = llm_cell.active_area
     # cell.stack_sequence = ' | '.join(llm_cell.layer_order.split(','))
-    cell.stack_sequence = '|'.join(
+    cell.stack_sequence = ' | '.join(
         'Perovskite' if layer.functionality == 'Absorber' else layer.name
         for layer in llm_cell.layers
     )

--- a/tests/test_llm_conversion.py
+++ b/tests/test_llm_conversion.py
@@ -36,24 +36,24 @@ def test_conversion(tmp_path):
     classic = llm_to_classic_schema(entry_archive.data)
     cell = classic.cell
     assert isinstance(cell, Cell)
-    assert cell.stack_sequence == 'FTO|TiO2-c|TiO2-mp|Perovskite|DTB(3%DEG)|Au'
+    assert cell.stack_sequence == 'FTO | TiO2-c | TiO2-mp | Perovskite | DTB(3%DEG) | Au'
 
     etl = classic.etl
     assert isinstance(etl, ETL)
-    assert etl.stack_sequence == 'TiO2-c|TiO2-mp'
-    assert etl.deposition_procedure == 'Spin-coating|Spin-coating'
-    assert etl.deposition_synthesis_atmosphere == 'Ambient air|Ambient air'
-    assert etl.deposition_solvents == '1-butanol|ethanol'
+    assert etl.stack_sequence == 'TiO2-c | TiO2-mp'
+    assert etl.deposition_procedure == 'Spin-coating | Spin-coating'
+    assert etl.deposition_synthesis_atmosphere == 'Ambient air | Ambient air'
+    assert etl.deposition_solvents == '1-butanol | ethanol'
     assert (
         etl.deposition_reaction_solutions_compounds
-        == 'titanium diisopropoxide bis(acetylacetonate)|TiO2 paste'
+        == 'titanium diisopropoxide bis(acetylacetonate) | TiO2 paste'
     )
-    assert etl.deposition_reaction_solutions_concentrations == '0.15 mol/L|14.3 wt%'
-    assert etl.deposition_thermal_annealing_temperature == '125>>450|500'
-    assert etl.deposition_thermal_annealing_time == '300>>1800|1800'
+    assert etl.deposition_reaction_solutions_concentrations == '0.15 mol/L | 14.3 wt%'
+    assert etl.deposition_thermal_annealing_temperature == '125 >> 450 | 500'
+    assert etl.deposition_thermal_annealing_time == '300 >> 1800 | 1800'
     assert (
         etl.deposition_thermal_annealing_atmosphere
-        == 'Ambient air>>Ambient air|Ambient air'
+        == 'Ambient air >> Ambient air | Ambient air'
     )
 
     htl = classic.htl
@@ -69,12 +69,12 @@ def test_conversion(tmp_path):
     assert perovskite_deposition.thermal_annealing_temperature == '100'
     assert perovskite_deposition.thermal_annealing_time == '7200'
     assert perovskite_deposition.thermal_annealing_atmosphere == 'Ambient air'
-    assert perovskite_deposition.solvents == 'DMF;DMSO'
-    assert perovskite_deposition.solvents_mixing_ratios == '0.9;0.1'
+    assert perovskite_deposition.solvents == 'DMF; DMSO'
+    assert perovskite_deposition.solvents_mixing_ratios == '0.9; 0.1'
     assert (
-        perovskite_deposition.reaction_solutions_compounds == 'FAI;PbI2;MABr;PbBr2;CsI'
+        perovskite_deposition.reaction_solutions_compounds == 'FAI; PbI2; MABr; PbBr2; CsI'
     )
     assert (
         perovskite_deposition.reaction_solutions_concentrations
-        == '172 mg/mL;507 mg/mL;22.4 mg/mL;73.4 mg/mL;1.5 mol/L'
+        == '172 mg/mL; 507 mg/mL; 22.4 mg/mL; 73.4 mg/mL; 1.5 mol/L'
     )


### PR DESCRIPTION
## Summary by Sourcery

Add spaces around pipe (‘|’), arrow (‘>>’), and semicolon (‘;’) separators in LLM‐generated string joins to improve readability, and update tests accordingly.

Enhancements:
- Include spaces around '|' separators in add_to_pipe_separated_list and direct string joins.
- Use ' >> ' instead of '>>' and '; ' instead of ';' for all join operations in layer property formatting.

Tests:
- Adjust expected stack_sequence, deposition, and solvent strings in tests to match new spacing conventions.