### PR TITLE
Update llm-extraction to work with nomad-lab 1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "nomad-docs>=0.1.3"
 ]
 extraction = [
-    "perla-extract>=0.0.5"
+    "perla-extract>=0.0.6"
 ]
 
 notebooks = [

--- a/src/perovskite_solar_cell_database/actions/llm_extractor/activities.py
+++ b/src/perovskite_solar_cell_database/actions/llm_extractor/activities.py
@@ -1,6 +1,7 @@
 import json
 import time
 
+from nomad.processing.data import Upload
 from temporalio import activity
 
 from perovskite_solar_cell_database.actions.llm_extractor.models import (
@@ -36,6 +37,11 @@ def get_list_of_pdfs(input_data: ExtractWorkflowInput) -> dict:
             if file_info.path.lower().endswith('.pdf'):
                 pdfs.append(file_info.path)
 
+    if not pdfs:
+        activity.logger.error(
+            f'No PDF files found in the upload ID: {input_data.upload_id}'
+        )
+
     return {
         'pdfs': pdfs,
     }
@@ -62,15 +68,15 @@ def extract_from_pdf(input_data: SingleExtractionInput) -> dict:
         input_data.user_id,
     )
     if upload_files is None:
-        error_msg = f'Upload files not found or can not be accessed for upload ID: {input_data.upload_id}'
-        activity.logger.error(error_msg)
-        return {'saved_cells': [], 'success': False, 'errors': [error_msg]}
+        activity.logger.error(
+            f'Upload files not found or can not be accessed for upload ID: {input_data.upload_id}'
+        )
+        return {'saved_cells': []}
 
     extracted_cells = []
     if not input_data.api_token or input_data.api_token.get_secret_value() == '':
-        error_msg = 'API token is required for LLM extraction'
-        activity.logger.warning(error_msg)
-        return {'saved_cells': [], 'success': False, 'errors': [error_msg]}
+        activity.logger.error('API token is required for LLM extraction')
+        return {'saved_cells': []}
     try:
         extracted_cells = pdf_to_solar_cells(
             pdf=upload_files.raw_file_object(input_data.pdf).os_path,
@@ -79,11 +85,8 @@ def extract_from_pdf(input_data: SingleExtractionInput) -> dict:
             logger=activity.logger,
         )
     except Exception as e:
-        error_msg = f'Error during LLM extraction from PDF: {e}'
         activity.logger.error('Error during LLM extraction from PDF.', exc_info=e)
-        if len(error_msg) > 10000:
-            error_msg = error_msg[:10000] + '... [truncated]'
-        return {'saved_cells': [], 'success': False, 'errors': [error_msg]}
+        return {'saved_cells': []}
 
     saved_cells = []
     for idx, cell in enumerate(extracted_cells):
@@ -97,15 +100,13 @@ def extract_from_pdf(input_data: SingleExtractionInput) -> dict:
             json.dump({'data': cell['data']}, f, indent=4)
         saved_cells.append(fname)
 
-    return {'saved_cells': saved_cells, 'success': True, 'errors': []}
+    return {'saved_cells': saved_cells}
 
 
 @activity.defn(name=ACTION_NAME + '.process_new_files')
 async def process_new_files(data: ProcessNewFilesInput) -> dict:
     """Process newly created entries in the upload, then return their references."""
     from nomad.actions.manager import get_upload_files
-    from nomad.app.v1.routers.uploads import get_upload_with_read_access
-    from nomad.datamodel import User
     from nomad.utils import generate_entry_id
 
     upload_files = get_upload_files(
@@ -113,29 +114,15 @@ async def process_new_files(data: ProcessNewFilesInput) -> dict:
         data.user_id,
     )
     if upload_files is None:
-        error_msg = f'Upload files not found or can not be accessed for upload ID: {data.upload_id}'
-        activity.logger.error(error_msg)
-        return {'refs': [], 'success': False, 'errors': [error_msg]}
-
-    file_operations = []
-
-    for path in data.result_path:
-        file_operations.append(
-            dict(
-                op='ADD',
-                path=upload_files.raw_file_object(path).os_path,
-                target_dir='results',
-                temporary=False,
-            )
+        activity.logger.error(
+            f'Upload files not found or can not be accessed for upload ID: {data.upload_id}'
         )
+        return {'refs': []}
 
     # Wait until the upload is not busy
     for i in range(MAX_ATTEMPT_NUM):
-        upload = get_upload_with_read_access(
-            data.upload_id,
-            User(user_id=data.user_id),
-            include_others=True,
-        )
+        # authorization already checked with get_upload_files, so we can directly access the upload
+        upload = Upload.get(data.upload_id)
 
         if not upload.process_running:
             break
@@ -144,12 +131,12 @@ async def process_new_files(data: ProcessNewFilesInput) -> dict:
             time.sleep(0.5)
             activity.logger.warning('Upload is currently being processed. Waiting...')
     else:
-        error_msg = f'Upload {data.upload_id} is busy for too long. Cannot process new files.'
-        activity.logger.error(error_msg)
-        return {'refs': [], 'success': False, 'errors': [error_msg]}
+        activity.logger.error(
+            f'Upload {data.upload_id} is busy for too long. Cannot process new files.'
+        )
+        return {'refs': []}
 
     handle = upload.process_upload(
-        file_operations=file_operations,
         path_filter='results',
         only_updated_files=True,
     )
@@ -164,7 +151,7 @@ async def process_new_files(data: ProcessNewFilesInput) -> dict:
                 f'../uploads/{upload.upload_id}/archive/{generate_entry_id(str(upload.upload_id), path)}#/data'
             )
 
-    return {'refs': result_entry_refs, 'success': True, 'errors': []}
+    return {'refs': result_entry_refs}
 
 
 @activity.defn(name=ACTION_NAME + '.remove_source_pdfs')

--- a/src/perovskite_solar_cell_database/actions/llm_extractor/activities.py
+++ b/src/perovskite_solar_cell_database/actions/llm_extractor/activities.py
@@ -10,10 +10,11 @@ from perovskite_solar_cell_database.actions.llm_extractor.models import (
     SingleExtractionInput,
 )
 
+ACTION_NAME = 'perovskite_solar_cell_database_llm_extractor'
 MAX_ATTEMPT_NUM = 100  # attempts to reprocess upload with new entries
 
 
-@activity.defn
+@activity.defn(name=ACTION_NAME + '.get_list_of_pdfs')
 def get_list_of_pdfs(input_data: ExtractWorkflowInput) -> dict:
     """
     Find all PDF files in the upload if authorized user has access to the upload.
@@ -40,7 +41,7 @@ def get_list_of_pdfs(input_data: ExtractWorkflowInput) -> dict:
     }
 
 
-@activity.defn
+@activity.defn(name=ACTION_NAME + '.extract_from_pdf')
 def extract_from_pdf(input_data: SingleExtractionInput) -> dict:
     """
     Extract perovskite solar cell data from a single PDF file using LLM,
@@ -99,7 +100,7 @@ def extract_from_pdf(input_data: SingleExtractionInput) -> dict:
     return {'saved_cells': saved_cells, 'success': True, 'errors': []}
 
 
-@activity.defn
+@activity.defn(name=ACTION_NAME + '.process_new_files')
 async def process_new_files(data: ProcessNewFilesInput) -> dict:
     """Process newly created entries in the upload, then return their references."""
     from nomad.actions.manager import get_upload_files
@@ -166,7 +167,7 @@ async def process_new_files(data: ProcessNewFilesInput) -> dict:
     return {'refs': result_entry_refs, 'success': True, 'errors': []}
 
 
-@activity.defn
+@activity.defn(name=ACTION_NAME + '.remove_source_pdfs')
 def remove_source_pdfs(input_data: CleanupInput) -> None:
     """
     Remove source PDF files from the upload after extraction.

--- a/src/perovskite_solar_cell_database/actions/llm_extractor/models.py
+++ b/src/perovskite_solar_cell_database/actions/llm_extractor/models.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel, Field, SecretStr, field_serializer
 ModelName = Literal[
     'gpt-4o',
     # 'gpt-5',  # Uncomment when temperature support is correct in LiteLLM
-    'claude-4-sonnet-20250514',
+    'claude-sonnet-4-6',
+    'claude-4-sonnet-20250514',  # retired; keep here so that old entries are not broken
     #  'meta.llama3-70b-instruct-v1:0',  # Uncomment when someone can test it
 ]  # Restricted set of LLM model names supported.
 
@@ -30,7 +31,7 @@ class ExtractWorkflowInput(BaseModel):
     )
     api_token: SecretStr = Field(..., description='API token for LLM access.')
     model: ModelName = Field(
-        'claude-4-sonnet-20250514', description='LLM model to be used for extraction.'
+        'claude-sonnet-4-6', description='LLM model to be used for extraction.'
     )
 
     @field_serializer('api_token', when_used='json')
@@ -51,7 +52,7 @@ class SingleExtractionInput(BaseModel):
     pdf: str = Field(..., description='Path to the PDF file to be processed.')
     api_token: SecretStr = Field(..., description='API token for LLM access.')
     model: ModelName = Field(
-        'claude-4-sonnet-20250514', description='LLM model to be used for extraction.'
+        'claude-sonnet-4-6', description='LLM model to be used for extraction.'
     )
 
     @field_serializer('api_token', when_used='json')

--- a/src/perovskite_solar_cell_database/actions/llm_extractor/utils.py
+++ b/src/perovskite_solar_cell_database/actions/llm_extractor/utils.py
@@ -13,7 +13,7 @@ def pdf_to_solar_cells(pdf: str, api_token: str, model: str, logger) -> list[dic
 
         return ExtractionPipeline(
             model, 'pymupdf', 'NONE', '', False
-        ).extract_from_pdf_nomad(filepath=pdf, api_key=api_token, ureg=ureg) # pyright: ignore[reportReturnType]
+        ).extract_from_pdf_nomad(filepath=pdf, api_key=api_token, ureg=ureg)  # pyright: ignore[reportReturnType]
     except ImportError as e:
         logger.error(
             'The perovskite-solar-cell-database plugin needs to be installed with the "extraction" extra to use LLM extraction.',
@@ -34,13 +34,13 @@ def test_pdf_to_solar_cells(pdf: str, api_token: str, model: str, logger) -> lis
         path_to_plugin = m.group(1)
     else:
         return []
-    print('#### Running test extraction mock-up, no real API call.')
+    logger.warning('#### Running test extraction mock-up, no real API call.')
     try:
         open(pdf, 'rb')
     except FileNotFoundError:
         logger.error(f'PDF file not found: {pdf}')
         return []
-    
+
     with open(
         f'{path_to_plugin}/tests/data/claude-4-sonnet-20250514-10.1002--aenm.201900555-cell-1.archive.json'
     ) as f:
@@ -58,10 +58,11 @@ def test_pdf_to_solar_cells(pdf: str, api_token: str, model: str, logger) -> lis
             logger.error('Error loading test extraction result.', exc_info=e)
 
     time.sleep(5)  # Simulate some processing time
+    logger.warning('Test warning.')
     return [cell_1, cell_2]
 
 
-def extract_doi(doi: str) -> str|None:
+def extract_doi(doi: str) -> str | None:
     """
     Extracts the DOI prefix and suffix (10.xxxx/xxxx) from a DOI string.
     Returns None if no valid DOI is found.

--- a/src/perovskite_solar_cell_database/actions/llm_extractor/workflows.py
+++ b/src/perovskite_solar_cell_database/actions/llm_extractor/workflows.py
@@ -23,7 +23,6 @@ with workflow.unsafe.imports_passed_through():
 class ExtractWorkflow:
     @workflow.run
     async def run(self, data: ExtractWorkflowInput) -> dict:
-        errors = []
         retry_policy = RetryPolicy(
             maximum_attempts=3,
         )
@@ -34,10 +33,7 @@ class ExtractWorkflow:
             retry_policy=retry_policy,
         )
         if not list_of_pdfs['pdfs']:
-            error_msg = 'No PDF files found in the upload.'
-            workflow.logger.error(error_msg)
-            errors.append(error_msg)
-            return {'refs': [], 'success': False, 'errors': errors}
+            return {'refs': []}
         try:
             all_saved_cells = []
             for pdf in list_of_pdfs['pdfs']:
@@ -56,8 +52,6 @@ class ExtractWorkflow:
                 )
                 saved_cells = extraction_result['saved_cells']
                 all_saved_cells.extend(saved_cells)
-                if not extraction_result['success']:
-                    errors.extend(extraction_result['errors'])
 
             input_for_processing = ProcessNewFilesInput(
                 upload_id=data.upload_id,
@@ -71,15 +65,9 @@ class ExtractWorkflow:
                 retry_policy=retry_policy,
             )
             result_entry_refs = processing_result['refs']
-            if not processing_result['success']:
-                errors.extend(processing_result['errors'])
         except ActivityError as e:
-            error_msg = f'Extraction activity failed: {e}'
-            workflow.logger.error(error_msg)
-            if len(error_msg) > 10000:
-                error_msg = error_msg[:10000] + '... [truncated]'
-            errors.append(error_msg)
-            return {'refs': [], 'success': False, 'errors': errors}
+            workflow.logger.error(f'Extraction activity failed: {e}')
+            return {'refs': []}
 
         finally:
             await workflow.execute_activity(
@@ -93,4 +81,4 @@ class ExtractWorkflow:
                 retry_policy=retry_policy,
             )
 
-        return {'refs': result_entry_refs, 'success': errors == [], 'errors': errors}
+        return {'refs': result_entry_refs}

--- a/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_dashboard.yaml
+++ b/src/perovskite_solar_cell_database/apps/perovskite_solar_cell_database_dashboard.yaml
@@ -1,100 +1,101 @@
-- type: scatter_plot
-  autorange: true
-  sample_size: 1000
-  markers:
-    color:
-      search_quantity: results.properties.optoelectronic.solar_cell.device_architecture
+widgets:
+  - type: scatter_plot
+    autorange: true
+    sample_size: 1000
+    markers:
+      color:
+        search_quantity: results.properties.optoelectronic.solar_cell.device_architecture
+        scale: linear
+    y:
+      title: Efficiency (%)
+      search_quantity: results.properties.optoelectronic.solar_cell.efficiency
       scale: linear
-  y:
-    title: Efficiency (%)
-    search_quantity: results.properties.optoelectronic.solar_cell.efficiency
-    scale: linear
-  x:
-    title: Bandgap
-    search_quantity: results.properties.electronic.band_gap[0].value
-    scale: linear
-  title: Efficiency vs Bandgap (1k random samples)
-  layout:
-    xxl:
-      minH: 3
-      minW: 3
-      h: 7
-      w: 11
-      y: 0
-      x: 0
-    xl:
-      minH: 3
-      minW: 3
-      h: 7
-      w: 10
-      y: 0
-      x: 0
-    lg:
-      minH: 3
-      minW: 3
-      h: 6
-      w: 9
-      y: 0
-      x: 0
-    md:
-      minH: 3
-      minW: 3
-      h: 5
-      w: 8
-      y: 0
-      x: 0
-    sm:
-      minH: 3
-      minW: 3
-      h: 5
-      w: 12
-      y: 0
-      x: 0
-- type: box_plot
-  autorange: true
-  subgroup_by_size: 5
-  subgroup_by: data.perovskite.composition_c_ions#perovskite_solar_cell_database.schema.PerovskiteSolarCell
-  group_by_size: 5
-  group_by: data.perovskite.composition_a_ions#perovskite_solar_cell_database.schema.PerovskiteSolarCell
-  show_points: true
-  sample_size: 1000
-  y:
-    search_quantity: data.jv.default_Voc#perovskite_solar_cell_database.schema.PerovskiteSolarCell
-    title: Open Circuit Voltage
-  title: Open Circuit Voltage Statistics (1k random samples)
-  layout:
-    xxl:
-      minH: 3
-      minW: 3
-      h: 7
-      w: 25
-      y: 0
-      x: 11
-    xl:
-      minH: 3
-      minW: 3
-      h: 7
-      w: 20
-      y: 0
-      x: 10
-    lg:
-      minH: 3
-      minW: 3
-      h: 6
-      w: 15
-      y: 0
-      x: 9
-    md:
-      minH: 3
-      minW: 3
-      h: 5
-      w: 10
-      y: 0
-      x: 8
-    sm:
-      minH: 3
-      minW: 3
-      h: 5
-      w: 12
-      y: 5
-      x: 0
+    x:
+      title: Bandgap
+      search_quantity: results.properties.electronic.band_gap[0].value
+      scale: linear
+    title: Efficiency vs Bandgap (1k random samples)
+    layout:
+      xxl:
+        minH: 3
+        minW: 3
+        h: 7
+        w: 11
+        y: 0
+        x: 0
+      xl:
+        minH: 3
+        minW: 3
+        h: 7
+        w: 10
+        y: 0
+        x: 0
+      lg:
+        minH: 3
+        minW: 3
+        h: 6
+        w: 9
+        y: 0
+        x: 0
+      md:
+        minH: 3
+        minW: 3
+        h: 5
+        w: 8
+        y: 0
+        x: 0
+      sm:
+        minH: 3
+        minW: 3
+        h: 5
+        w: 12
+        y: 0
+        x: 0
+  - type: box_plot
+    autorange: true
+    subgroup_by_size: 5
+    subgroup_by: data.perovskite.composition_c_ions#perovskite_solar_cell_database.schema.PerovskiteSolarCell
+    group_by_size: 5
+    group_by: data.perovskite.composition_a_ions#perovskite_solar_cell_database.schema.PerovskiteSolarCell
+    show_points: true
+    sample_size: 1000
+    y:
+      search_quantity: data.jv.default_Voc#perovskite_solar_cell_database.schema.PerovskiteSolarCell
+      title: Open Circuit Voltage
+    title: Open Circuit Voltage Statistics (1k random samples)
+    layout:
+      xxl:
+        minH: 3
+        minW: 3
+        h: 7
+        w: 25
+        y: 0
+        x: 11
+      xl:
+        minH: 3
+        minW: 3
+        h: 7
+        w: 20
+        y: 0
+        x: 10
+      lg:
+        minH: 3
+        minW: 3
+        h: 6
+        w: 15
+        y: 0
+        x: 9
+      md:
+        minH: 3
+        minW: 3
+        h: 5
+        w: 10
+        y: 0
+        x: 8
+      sm:
+        minH: 3
+        minW: 3
+        h: 5
+        w: 12
+        y: 5
+        x: 0

--- a/src/perovskite_solar_cell_database/schema_packages/llm_extractor.py
+++ b/src/perovskite_solar_cell_database/schema_packages/llm_extractor.py
@@ -1,9 +1,15 @@
+import json
 from typing import (
     TYPE_CHECKING,
     get_args,
 )
 
-from nomad.actions.manager import get_action_result, get_action_status, start_action
+from nomad.actions.manager import (
+    action_log_file_path,
+    get_action_result,
+    get_action_status,
+    start_action,
+)
 from nomad.datamodel.data import UseCaseElnCategory
 from nomad.datamodel.metainfo.annotations import ELNComponentEnum, SectionProperties
 from nomad.datamodel.metainfo.eln import ELNAnnotation
@@ -64,7 +70,7 @@ class LlmPerovskitePaperExtractor(Schema):
             *get_args(ModelName)
         ),  # an enum of supported model names - better way of defining model and ModelName from one constant does not work in python 3.10
         description='LLM model to use for extraction',
-        default='claude-4-sonnet-20250514',
+        default='claude-sonnet-4-6',
         a_eln=ELNAnnotation(component=ELNComponentEnum.EnumEditQuantity),
     )
     trigger_run_action = Quantity(
@@ -138,12 +144,26 @@ class LlmPerovskitePaperExtractor(Schema):
                     archive.metadata.authors[0].user_id,  # type: ignore
                 )
                 if result_refs is not None:
-                    if result_refs.get('success'):
+                    action_log_path = action_log_file_path(self.action_id)  # pyright: ignore[reportArgumentType]
+                    success_flag = True
+                    with open(action_log_path) as f:
+                        for line in f:
+                            if line.strip():
+                                try:
+                                    # some log entries might be non-JSON, skip them for now
+                                    log_entry = json.loads(line)
+                                    if log_entry.get('level') == 'ERROR':
+                                        success_flag = False
+                                        break
+                                except json.JSONDecodeError:
+                                    pass
+
+                    if success_flag:
                         self.extracted_solar_cells = result_refs['refs']
                     else:
                         self.action_status = 'FAILED'
                         logger.error(
-                            f'LLM Extraction action completed with errors: {result_refs.get("errors")}'
+                            'LLM Extraction action completed with errors. See action logs for details.'
                         )
                 else:
                     self.extracted_solar_cells = []


### PR DESCRIPTION
Fixes updating llm-extraction of perovskite papers to be compatible with `nomad-lab==1.4.2`.
 - `upload.process_upload()` now works slightly differently; `file_operations` are not needed anymore and were actually breaking resulting entries - parameter removed
 - user rights are now checked with functions from `nomad.actions.manager` instead of `nomad.app.v1.routers` - the latter are designed to work with FastAPI and are not guarantied to function correctly in normalization / activities later on.
 - activities definition now includes long name including plugin/action - avoid potential conflict with other plugins using similarly named activities
 - use temporal logging for activities now supported by nomad instead of temporary self-made replacement
 - add new claude model to the list of available ones and as a default